### PR TITLE
Add support to hubot-slack 4.0, as it's not using channel name anymore

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -18,8 +18,11 @@ module.exports = (robot) ->
     robot.logger.error 'whitelist is not an array!'
 
   robot.receiveMiddleware (context, next, done) ->
+    # Get channel name from client's cache (https://github.com/slackapi/hubot-slack/issues/328)
+    channelName = robot.adapter.client.rtm.dataStore.getChannelGroupOrDMById(reach(context, 'response.envelope.room')).name
+
     # Unless the room is in the whitelist
-    unless reach(context, 'response.envelope.room') in whitelist
+    unless channelName in whitelist
       # We're done
       context.response.message.finish()
       done()


### PR DESCRIPTION
https://github.com/slackapi/hubot-slack/issues/328

Since hubot-slack 4.0 ```response.envelope.room.envelope``` returns the channel id instead of its name. So I am using this ID to get the channel name from slack client's cache as stated here https://github.com/slackapi/hubot-slack/issues/328#issuecomment-237861067
